### PR TITLE
fix for gmail smarthosts

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -45,7 +45,7 @@ template "/etc/exim4/passwd.client" do
   group node[:exim4][:user]
   mode 0640
   variables({
-    :smarthost_server => node[:exim4][:smarthost_server],
+    :smarthost_server => (node[:exim4][:smarthost_auth_server] || node[:exim4][:smarthost_server]),
     :smarthost_login => login,
     :smarthost_pwd => pwd
   })


### PR DESCRIPTION
allow the servername used for authentication to be different from the
smarthost_server variable. In case of gmail you need smtp.gmail.com as the
smarthost, but in passwd.client you need *.google.com...
